### PR TITLE
Database read throttle (#242)

### DIFF
--- a/example-config.json
+++ b/example-config.json
@@ -9,7 +9,8 @@
             "keyspace":"clio",
             "replication_factor":1,
             "table_prefix":"",
-            "max_requests_outstanding":25000,
+            "max_write_requests_outstanding":25000,
+            "max_read_requests_outstanding":30000,
             "threads":8
         }
     },

--- a/src/backend/BackendInterface.h
+++ b/src/backend/BackendInterface.h
@@ -7,10 +7,12 @@
 #include <backend/Types.h>
 #include <thread>
 #include <type_traits>
+
 namespace Backend {
 
 class DatabaseTimeout : public std::exception
 {
+public:
     const char*
     what() const throw() override
     {
@@ -30,9 +32,10 @@ retryOnTimeout(F func, size_t waitMs = 500)
         }
         catch (DatabaseTimeout& t)
         {
-            std::this_thread::sleep_for(std::chrono::milliseconds(waitMs));
             BOOST_LOG_TRIVIAL(error)
-                << __func__ << " function timed out. Retrying ... ";
+                << __func__
+                << " Database request timed out. Sleeping and retrying ... ";
+            std::this_thread::sleep_for(std::chrono::milliseconds(waitMs));
         }
     }
 }
@@ -341,6 +344,9 @@ public:
     // Close the database, releasing any resources
     virtual void
     close(){};
+
+    virtual bool
+    isTooBusy() const = 0;
 
     // *** private helper methods
 private:

--- a/src/backend/CassandraBackend.h
+++ b/src/backend/CassandraBackend.h
@@ -645,13 +645,18 @@ private:
     uint32_t syncInterval_ = 1;
     uint32_t lastSync_ = 0;
 
-    // maximum number of concurrent in flight requests. New requests will wait
-    // for earlier requests to finish if this limit is exceeded
-    std::uint32_t maxRequestsOutstanding = 10000;
-    mutable std::atomic_uint32_t numRequestsOutstanding_ = 0;
+    // maximum number of concurrent in flight write requests. New requests will
+    // wait for earlier requests to finish if this limit is exceeded
+    std::uint32_t maxWriteRequestsOutstanding = 10000;
+    mutable std::atomic_uint32_t numWriteRequestsOutstanding_ = 0;
+
+    // maximum number of concurrent in flight read requests. isTooBusy() will
+    // return true if the number of in flight read requests exceeds this limit
+    std::uint32_t maxReadRequestsOutstanding = 100000;
+    mutable std::atomic_uint32_t numReadRequestsOutstanding_ = 0;
 
     // mutex and condition_variable to limit the number of concurrent in flight
-    // requests
+    // write requests
     mutable std::mutex throttleMutex_;
     mutable std::condition_variable throttleCv_;
 
@@ -1017,6 +1022,9 @@ public:
         std::uint32_t const numLedgersToKeep,
         boost::asio::yield_context& yield) const override;
 
+    bool
+    isTooBusy() const override;
+
     inline void
     incremementOutstandingRequestCount() const
     {
@@ -1031,19 +1039,19 @@ public:
                 throttleCv_.wait(lck, [this]() { return canAddRequest(); });
             }
         }
-        ++numRequestsOutstanding_;
+        ++numWriteRequestsOutstanding_;
     }
 
     inline void
     decrementOutstandingRequestCount() const
     {
         // sanity check
-        if (numRequestsOutstanding_ == 0)
+        if (numWriteRequestsOutstanding_ == 0)
         {
             assert(false);
             throw std::runtime_error("decrementing num outstanding below 0");
         }
-        size_t cur = (--numRequestsOutstanding_);
+        size_t cur = (--numWriteRequestsOutstanding_);
         {
             // mutex lock required to prevent race condition around spurious
             // wakeup
@@ -1062,13 +1070,13 @@ public:
     inline bool
     canAddRequest() const
     {
-        return numRequestsOutstanding_ < maxRequestsOutstanding;
+        return numWriteRequestsOutstanding_ < maxWriteRequestsOutstanding;
     }
 
     inline bool
     finishedAllRequests() const
     {
-        return numRequestsOutstanding_ == 0;
+        return numWriteRequestsOutstanding_ == 0;
     }
 
     void
@@ -1209,10 +1217,12 @@ public:
         CassError rc;
         do
         {
+            ++numReadRequestsOutstanding_;
             fut = cass_session_execute(session_.get(), statement.get());
 
             boost::system::error_code ec;
             rc = cass_future_error_code(fut, yield[ec]);
+            --numReadRequestsOutstanding_;
 
             if (ec)
             {

--- a/src/backend/PostgresBackend.h
+++ b/src/backend/PostgresBackend.h
@@ -157,6 +157,12 @@ public:
     doFinishWrites() override;
 
     bool
+    isTooBusy() const override
+    {
+        return false;
+    }
+
+    bool
     doOnlineDelete(
         std::uint32_t const numLedgersToKeep,
         boost::asio::yield_context& yield) const override;


### PR DESCRIPTION
Track current outstanding read requests to the database. When the configured limit is exceeded, reject new RPCs and return rpcTOO_BUSY